### PR TITLE
Add deep formatting when translate Word documents

### DIFF
--- a/.idea/VaultSpell.iml
+++ b/.idea/VaultSpell.iml
@@ -4,7 +4,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="Python 3.11 (VaultSpell)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.10 (VaultSpell)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.11 (VaultSpell)" project-jdk-type="Python SDK" />
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/main.py
+++ b/main.py
@@ -1,37 +1,5 @@
 import argparse as args
-import time
-
-import docx
-
-from vault.translator import *
-from vault.bar import *
-
-
-def CreateDocument(src, dest, langs):
-    doc = docx.Document(src)
-    styles = [p.style for p in doc.paragraphs]
-    array = [p.text for p in doc.paragraphs]
-    ok = True
-
-    n = len(array)
-    util = GoogleTranslate()
-
-    doc = docx.Document()
-    showProgress(0, n, prefix='Progress:', suffix='Complete', length=25)
-
-    for i, line in enumerate(array):
-        try:
-            newLine = util.GetText(line, src=langs[0], dest=langs[1])
-            doc.add_paragraph(newLine, style=styles[i])
-            time.sleep(1)
-            showProgress(i + 1, n, prefix='Progress:', suffix='Complete', length=25)
-        except AttributeError:
-            ok = False
-            break
-
-    if ok:
-        doc.save(dest)
-        print("\n Successfully translate document!")
+from vault.utils import VaultCore
 
 
 if __name__ == "__main__":
@@ -46,4 +14,4 @@ if __name__ == "__main__":
 
     dest = args.output
     langs = args.langs
-    CreateDocument(src, dest, langs)
+    VaultCore.CreateDocument(src, dest, langs)

--- a/vault/__init__.py
+++ b/vault/__init__.py
@@ -1,2 +1,3 @@
 import vault.translator
 import vault.bar
+import vault.utils

--- a/vault/utils.py
+++ b/vault/utils.py
@@ -1,0 +1,47 @@
+import docx
+from vault.translator import *
+from vault.bar import *
+import time
+
+
+class VaultCore:
+    @staticmethod
+    def CreateDocument(src, dest, langs):
+        doc = docx.Document(src)
+        paragraphs = doc.paragraphs
+        ok = True
+
+        n = len(paragraphs)
+        util = GoogleTranslate()
+
+        newDoc = docx.Document()
+        showProgress(0, n, prefix='Progress:', suffix='Complete', length=25)
+
+        for i, line in enumerate(paragraphs):
+            try:
+                VaultCore.WriteParagraph(util, newDoc, paragraphs[i], langs)
+                time.sleep(.2)
+                showProgress(i + 1, n, prefix='Progress:', suffix='Complete', length=25)
+            except AttributeError:
+                ok = False
+                break
+
+        if ok:
+            newDoc.save(dest)
+            print("\n Successfully translate document!")
+
+    @staticmethod
+    def WriteParagraph(util, doc, paragraph, langs):
+        newParagraph = doc.add_paragraph()
+
+        for run in paragraph.runs:
+            newLine = util.GetText(run.text, src=langs[0], dest=langs[1])
+            output_run = newParagraph.add_run(newLine)
+            output_run.bold = run.bold
+            output_run.italic = run.italic
+
+            output_run.underline = run.underline
+            output_run.font.color.rgb = run.font.color.rgb
+            output_run.style.name = run.style.name
+
+        newParagraph.paragraph_format.alignment = paragraph.paragraph_format.alignment

--- a/vault/utils.py
+++ b/vault/utils.py
@@ -1,12 +1,13 @@
 import docx
 from vault.translator import *
+from docx.text.paragraph import Paragraph
 from vault.bar import *
 import time
 
 
 class VaultCore:
     @staticmethod
-    def CreateDocument(src, dest, langs):
+    def CreateDocument(src: str, dest: str, langs: list[str]):
         doc = docx.Document(src)
         paragraphs = doc.paragraphs
         ok = True
@@ -20,7 +21,7 @@ class VaultCore:
         for i, line in enumerate(paragraphs):
             try:
                 VaultCore.WriteParagraph(util, newDoc, paragraphs[i], langs)
-                time.sleep(.2)
+                time.sleep(.05)
                 showProgress(i + 1, n, prefix='Progress:', suffix='Complete', length=25)
             except AttributeError:
                 ok = False
@@ -31,17 +32,52 @@ class VaultCore:
             print("\n Successfully translate document!")
 
     @staticmethod
-    def WriteParagraph(util, doc, paragraph, langs):
+    def GetText(src: str, dest: str):
+        size = len(src)
+        v = [' ', '\t', '\n']
+        res = src
+        ok = True
+
+        if size >= 2:
+            for i in range(len(v)):
+                if src[0] == v[i]:
+                    ok = False
+                    break
+
+            if not ok:
+                res = "{}{}".format(src[0], dest)
+
+            ok = True
+
+            for i in range(len(v)):
+                if src[size - 1] == v[i]:
+                    ok = False
+                    break
+
+            if not ok:
+                res = "{}{}".format(dest, src[size - 1])
+
+            return res
+
+        return dest
+
+    @staticmethod
+    def WriteParagraph(util: GoogleTranslate, doc: docx.Document, paragraph: Paragraph, langs: list[str]):
         newParagraph = doc.add_paragraph()
 
         for run in paragraph.runs:
-            newLine = util.GetText(run.text, src=langs[0], dest=langs[1])
-            output_run = newParagraph.add_run(newLine)
-            output_run.bold = run.bold
-            output_run.italic = run.italic
+            if "pic:pic" in run.element.xml:
+                newParagraph.runs.append(run)
+            else:
+                newLine = util.GetText(run.text, src=langs[0], dest=langs[1])
+                newLine = VaultCore.GetText(run.text, newLine)
 
-            output_run.underline = run.underline
-            output_run.font.color.rgb = run.font.color.rgb
-            output_run.style.name = run.style.name
+                output_run = newParagraph.add_run(newLine)
+                output_run.bold = run.bold
+                output_run.italic = run.italic
+
+                output_run.underline = run.underline
+                output_run.font.color.rgb = run.font.color.rgb
+                output_run.style.name = run.style.name
 
         newParagraph.paragraph_format.alignment = paragraph.paragraph_format.alignment


### PR DESCRIPTION
Add deep formatting when translate Word documents to keep their XML schema and old structure.